### PR TITLE
feat: add storybook design system foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Thumbs.db
 .github/copilot-instructions.local.md
 
 .vercel/
+
+*storybook.log
+storybook-static

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,13 @@
+import type { StorybookConfig } from "@storybook/html-vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  addons: ["@storybook/addon-docs"],
+  framework: "@storybook/html-vite",
+  docs: {
+    autodocs: "tag",
+  },
+  staticDirs: ["../public"],
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,22 @@
+import type { Preview } from "@storybook/html-vite";
+
+import "../src/styles.css";
+
+const preview: Preview = {
+  parameters: {
+    layout: "centered",
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    docs: {
+      story: {
+        inline: true,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ Examples:
   - `bun run test`
   - `bun run build`
 - Pull requests are expected to pass the GitHub Actions CI workflow.
+- If you touch the design-system or Storybook stories, also run `bun run build-storybook`.
 
 ## Deployment
 - Vercel is the primary hosting target for preview and production deployments.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Socket Shift is an original TypeScript puzzle game about guiding a maintenance d
 - Semantic-release configuration with changelog generation
 - Issue and pull request templates for a clean GitHub workflow
 - GitHub Actions CI and Vercel-ready deployment configuration
+- Storybook-backed design-system foundation for current shell components
 
 ## 🧭 Project Milestones
 ### Milestone 01: Playable Prototype
@@ -83,6 +84,7 @@ Useful docs:
 - [CONTRIBUTING.md](./CONTRIBUTING.md)
 - [docs/code-guidelines.md](./docs/code-guidelines.md)
 - [docs/deployment.md](./docs/deployment.md)
+- [docs/design-system.md](./docs/design-system.md)
 - [CHANGELOG.md](./CHANGELOG.md)
 
 ## 🚀 Quick Start
@@ -99,6 +101,7 @@ bun run dev
 ### Quality checks
 ```bash
 bun run verify
+bun run build-storybook
 ```
 
 ## ☁️ Deployment
@@ -120,6 +123,7 @@ Preview and production deployments are handled through Vercel's GitHub integrati
 - Biome
 - GitHub Actions
 - Vercel
+- Storybook
 - commitlint
 - lefthook
 - semantic-release

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,12 +51,14 @@ Status: planned
 Goals:
 - Add undo and move history
 - Add more levels and simple progression
+- Establish the first Storybook-backed design-system layer
 - Improve win/reset flow and in-game status feedback
 
 Deliverables:
 - Undo support
 - Level registry and progression system
 - Better state transitions around reset and completion
+- Documented shell components and design tokens
 
 ## 🟣 Milestone 05: Delight and Accessibility
 Status: planned

--- a/bun.lock
+++ b/bun.lock
@@ -13,8 +13,11 @@
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^12.0.6",
         "@semantic-release/release-notes-generator": "^14.1.0",
+        "@storybook/addon-docs": "^10.2.19",
+        "@storybook/html-vite": "^10.2.19",
         "lefthook": "^2.1.4",
         "semantic-release": "^25.0.3",
+        "storybook": "^10.2.19",
         "typescript": "^5.9.2",
         "vite": "^7.1.3",
         "vitest": "^3.2.4",
@@ -30,9 +33,13 @@
 
     "@actions/io": ["@actions/io@3.0.2", "", {}, "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="],
 
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
     "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
 
@@ -142,7 +149,17 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
 
     "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
@@ -246,15 +263,43 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@storybook/addon-docs": ["@storybook/addon-docs@10.2.19", "", { "dependencies": { "@mdx-js/react": "^3.0.0", "@storybook/csf-plugin": "10.2.19", "@storybook/icons": "^2.0.1", "@storybook/react-dom-shim": "10.2.19", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.2.19" } }, "sha512-tXugthdzjX5AkGWDSP4pnRgA/CWlOaEKp/+y9JOGXHLQmm1GHjW+4brNvNkKbjBl06LALXwlcTOyU4lyVRDLAw=="],
+
+    "@storybook/builder-vite": ["@storybook/builder-vite@10.2.19", "", { "dependencies": { "@storybook/csf-plugin": "10.2.19", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.2.19", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-a59xALzM9GeYh6p+wzAeBbDyIe+qyrC4nxS3QNzb5i2ZOhrq1iIpvnDaOWe80NC8mV3IlqUEGY8Uawkf//1Rmg=="],
+
+    "@storybook/csf-plugin": ["@storybook/csf-plugin@10.2.19", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.2.19", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-BpjYIOdyQn/Rm6MjUAc5Gl8HlARZrskD/OhUNShiOh2fznb523dHjiE5mbU1kKM/+L1uvRlEqqih40rTx+xCrg=="],
+
+    "@storybook/global": ["@storybook/global@5.0.0", "", {}, "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="],
+
+    "@storybook/html": ["@storybook/html@10.2.19", "", { "dependencies": { "@storybook/global": "^5.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.2.19" } }, "sha512-5t2Vj8koYG3djjoY7I6KiYRXyHElB2+SGGm+6i2fDDYzLSBRycKBgSJMnA4V4bXEFnVYwcfJUZ/TO4a3ciDmNg=="],
+
+    "@storybook/html-vite": ["@storybook/html-vite@10.2.19", "", { "dependencies": { "@storybook/builder-vite": "10.2.19", "@storybook/html": "10.2.19" }, "peerDependencies": { "storybook": "^10.2.19" } }, "sha512-XzPqeRCO4DAym9uKu+9y7pFfBSXI3sdQby0ViMFWr9/z2myThIi67HEQ7soiU8RZzot842oGYUwOjloHuIUJ0A=="],
+
+    "@storybook/icons": ["@storybook/icons@2.0.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg=="],
+
+    "@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.2.19", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.19" } }, "sha512-BXCEfBGVBRYBTYeBeH/PJsy0Bq5MERe/HiaylR+ah/XrvIr2Z9bkne1J8yYiXCjiyq5HQa7Bj11roz0+vyUaEw=="],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/mdx": ["@types/mdx@2.0.13", "", {}, "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw=="],
+
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
@@ -269,6 +314,8 @@
     "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -288,15 +335,21 @@
 
     "argv-formatter": ["argv-formatter@1.0.0", "", {}, "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw=="],
 
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
@@ -348,13 +401,27 @@
 
     "crypto-random-string": ["crypto-random-string@4.0.0", "", { "dependencies": { "type-fest": "^1.0.1" } }, "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA=="],
 
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
 
@@ -379,6 +446,8 @@
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -460,7 +529,11 @@
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -471,6 +544,8 @@
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
@@ -554,6 +629,8 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "make-asynchronous": ["make-asynchronous@1.1.0", "", { "dependencies": { "p-event": "^6.0.0", "type-fest": "^4.6.0", "web-worker": "^1.5.0" } }, "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg=="],
@@ -571,6 +648,8 @@
     "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -597,6 +676,8 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "p-each-series": ["p-each-series@3.0.0", "", {}, "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw=="],
 
@@ -648,6 +729,8 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
@@ -656,11 +739,21 @@
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
+    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+
+    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "read-package-up": ["read-package-up@11.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
 
     "read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "registry-auth-token": ["registry-auth-token@5.1.1", "", { "dependencies": { "@pnpm/npm-conf": "^3.0.2" } }, "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q=="],
 
@@ -672,7 +765,11 @@
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semantic-release": ["semantic-release@25.0.3", "", { "dependencies": { "@semantic-release/commit-analyzer": "^13.0.1", "@semantic-release/error": "^4.0.0", "@semantic-release/github": "^12.0.0", "@semantic-release/npm": "^13.1.1", "@semantic-release/release-notes-generator": "^14.1.0", "aggregate-error": "^5.0.0", "cosmiconfig": "^9.0.0", "debug": "^4.0.0", "env-ci": "^11.0.0", "execa": "^9.0.0", "figures": "^6.0.0", "find-versions": "^6.0.0", "get-stream": "^6.0.0", "git-log-parser": "^1.2.0", "hook-std": "^4.0.0", "hosted-git-info": "^9.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "marked": "^15.0.0", "marked-terminal": "^7.3.0", "micromatch": "^4.0.2", "p-each-series": "^3.0.0", "p-reduce": "^3.0.0", "read-package-up": "^12.0.0", "resolve-from": "^5.0.0", "semver": "^7.3.2", "signale": "^1.2.1", "yargs": "^18.0.0" }, "bin": { "semantic-release": "bin/semantic-release.js" } }, "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA=="],
 
@@ -712,6 +809,8 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "storybook": ["storybook@10.2.19", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.1", "@testing-library/jest-dom": "^6.6.3", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0", "open": "^10.2.0", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "prettier": "^2 || ^3" }, "optionalPeers": ["prettier"], "bin": "./dist/bin/dispatcher.js" }, "sha512-UUm5eGSm6BLhkcFP0WbxkmAHJZfVN2ViLpIZOqiIPS++q32VYn+CLFC0lrTYTDqYvaG7i4BK4uowXYujzE4NdQ=="],
+
     "stream-combiner2": ["stream-combiner2@1.1.1", "", { "dependencies": { "duplexer2": "~0.1.0", "readable-stream": "^2.0.2" } }, "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -723,6 +822,8 @@
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
@@ -748,6 +849,8 @@
 
     "time-span": ["time-span@5.1.0", "", { "dependencies": { "convert-hrtime": "^5.0.0" } }, "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
@@ -763,6 +866,10 @@
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "traverse": ["traverse@0.6.8", "", {}, "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA=="],
+
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
 
@@ -786,7 +893,11 @@
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
+    "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
+
     "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
@@ -800,6 +911,8 @@
 
     "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
 
+    "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
@@ -807,6 +920,10 @@
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -835,6 +952,10 @@
     "@semantic-release/npm/execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
     "@semantic-release/npm/read-pkg": ["read-pkg@10.1.0", "", { "dependencies": { "@types/normalize-package-data": "^2.4.4", "normalize-package-data": "^8.0.0", "parse-json": "^8.3.0", "type-fest": "^5.4.4", "unicorn-magic": "^0.4.0" } }, "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1149,6 +1270,10 @@
     "npm/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
+    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "read-pkg/parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,25 @@
+# Design System
+
+## Scope
+The first Storybook pass focuses on the real UI already present in the game shell:
+- shell layout
+- control buttons
+- stat cards
+- status banner
+- board surface container
+
+The puzzle engine, board-state transitions, and input loop stay outside the design-system boundary.
+
+## Principles
+- Use semantic tokens for surfaces, text, and accents.
+- Keep component APIs narrow and purposeful.
+- Prefer real game UI over invented example components.
+- Let Storybook and code act as the source of truth for shipped behavior.
+- Use Figma and Figma Make for exploration, motion studies, and communication, not for runtime ownership.
+
+## Material Influence
+The system borrows from Material-style thinking in a lightweight way:
+- surfaces are layered intentionally
+- stateful components expose clear variants
+- layout primitives are documented as reusable building blocks
+- elevation, emphasis, and readable spacing matter more than literal visual mimicry

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "prepare": "lefthook install",
     "release": "semantic-release",
     "release:dry-run": "semantic-release --dry-run",
-    "verify": "bun run lint && bun run test && bun run build"
+    "verify": "bun run lint && bun run test && bun run build",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
@@ -31,6 +33,9 @@
     "semantic-release": "^25.0.3",
     "typescript": "^5.9.2",
     "vite": "^7.1.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "storybook": "^10.2.19",
+    "@storybook/html-vite": "^10.2.19",
+    "@storybook/addon-docs": "^10.2.19"
   }
 }

--- a/src/design-system/components/board-surface.ts
+++ b/src/design-system/components/board-surface.ts
@@ -1,0 +1,26 @@
+import { escapeHtml } from "../shared/escape-html";
+
+export type BoardSurfaceMarkupOptions = {
+  ariaLabel?: string;
+  columns: number;
+  dataAttribute?: string;
+};
+
+export const createBoardSurfaceMarkup = ({
+  ariaLabel = "Puzzle grid",
+  columns,
+  dataAttribute,
+}: BoardSurfaceMarkupOptions): string => {
+  const attributes = [
+    'class="board board-surface"',
+    `style="grid-template-columns: repeat(${columns}, minmax(0, 1fr));"`,
+    'role="img"',
+    `aria-label="${escapeHtml(ariaLabel)}"`,
+  ];
+
+  if (dataAttribute) {
+    attributes.push(dataAttribute);
+  }
+
+  return `<div ${attributes.join(" ")}></div>`;
+};

--- a/src/design-system/components/button.ts
+++ b/src/design-system/components/button.ts
@@ -1,0 +1,29 @@
+import { escapeHtml } from "../shared/escape-html";
+
+export type ControlButtonTone = "ghost" | "primary";
+
+export type ControlButtonMarkupOptions = {
+  ariaPressed?: boolean;
+  dataAttribute?: string;
+  label: string;
+  tone?: ControlButtonTone;
+};
+
+export const createControlButtonMarkup = ({
+  ariaPressed,
+  dataAttribute,
+  label,
+  tone = "primary",
+}: ControlButtonMarkupOptions): string => {
+  const attributes = ['type="button"', `class="control-button control-button--${tone}"`];
+
+  if (dataAttribute) {
+    attributes.push(dataAttribute);
+  }
+
+  if (typeof ariaPressed === "boolean") {
+    attributes.push(`aria-pressed="${String(ariaPressed)}"`);
+  }
+
+  return `<button ${attributes.join(" ")}>${escapeHtml(label)}</button>`;
+};

--- a/src/design-system/components/stat-card.ts
+++ b/src/design-system/components/stat-card.ts
@@ -1,0 +1,22 @@
+import { escapeHtml } from "../shared/escape-html";
+
+export type StatCardMarkupOptions = {
+  label: string;
+  value: string;
+  valueAttributes?: string;
+};
+
+export const createStatCardMarkup = ({
+  label,
+  value,
+  valueAttributes,
+}: StatCardMarkupOptions): string => {
+  const attributes = valueAttributes ? ` ${valueAttributes}` : "";
+
+  return `
+    <div class="stat-card">
+      <span class="label">${escapeHtml(label)}</span>
+      <strong class="stat-card__value"${attributes}>${escapeHtml(value)}</strong>
+    </div>
+  `;
+};

--- a/src/design-system/components/status-banner.ts
+++ b/src/design-system/components/status-banner.ts
@@ -1,0 +1,23 @@
+import { escapeHtml } from "../shared/escape-html";
+
+export type StatusBannerTone = "default" | "won";
+
+export type StatusBannerMarkupOptions = {
+  dataAttribute?: string;
+  message: string;
+  tone?: StatusBannerTone;
+};
+
+export const createStatusBannerMarkup = ({
+  dataAttribute,
+  message,
+  tone = "default",
+}: StatusBannerMarkupOptions): string => {
+  const attributes = [`class="status status-banner${tone === "won" ? " status-banner--won" : ""}"`];
+
+  if (dataAttribute) {
+    attributes.push(dataAttribute);
+  }
+
+  return `<div ${attributes.join(" ")}>${escapeHtml(message)}</div>`;
+};

--- a/src/design-system/foundations/tokens.css
+++ b/src/design-system/foundations/tokens.css
@@ -1,0 +1,23 @@
+:root {
+  color-scheme: dark;
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+  font-size: 16px;
+  text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  --bg-0: #08111d;
+  --bg-1: #0f1d30;
+  --bg-2: #16273d;
+  --panel: rgba(9, 15, 26, 0.76);
+  --panel-border: rgba(255, 255, 255, 0.09);
+  --text: #f5efe0;
+  --muted: #9bb2c7;
+  --accent-warm: #ffb95e;
+  --accent-hot: #ff7d48;
+  --accent-cool: #73f6ff;
+  --accent-win: #9effd9;
+  --floor: #13243b;
+  --wall: #372923;
+  --radius-panel: 28px;
+  --radius-card: 18px;
+  --shadow-panel: 0 28px 80px rgba(0, 0, 0, 0.35);
+}

--- a/src/design-system/layouts/game-shell.ts
+++ b/src/design-system/layouts/game-shell.ts
@@ -1,0 +1,65 @@
+import { createBoardSurfaceMarkup } from "../components/board-surface";
+import { createControlButtonMarkup } from "../components/button";
+import { createStatCardMarkup } from "../components/stat-card";
+import { createStatusBannerMarkup } from "../components/status-banner";
+import { escapeHtml } from "../shared/escape-html";
+
+export type GameShellMarkupOptions = {
+  boardAriaLabel?: string;
+  boardColumns: number;
+  levelName: string;
+  moves: string;
+  socketCount: string;
+  soundEnabled: boolean;
+  statusMessage: string;
+  won?: boolean;
+};
+
+export const createGameShellMarkup = ({
+  boardAriaLabel = "Puzzle grid with walls, sockets, power cells, and the player",
+  boardColumns,
+  levelName,
+  moves,
+  socketCount,
+  soundEnabled,
+  statusMessage,
+  won = false,
+}: GameShellMarkupOptions): string => {
+  return `
+    <main class="shell">
+      <section class="panel intro">
+        <p class="eyebrow">${escapeHtml(levelName)}</p>
+        <h1>Socket Shift</h1>
+        <p class="lede">
+          Guide the maintenance drone and push every power cell into a live socket.
+        </p>
+        <div class="stats">
+          ${createStatCardMarkup({ label: "Moves", value: moves, valueAttributes: "data-moves" })}
+          ${createStatCardMarkup({ label: "Sockets", value: socketCount })}
+        </div>
+        <div class="actions">
+          ${createControlButtonMarkup({ label: "Reset level", dataAttribute: "data-reset" })}
+          ${createControlButtonMarkup({
+            ariaPressed: soundEnabled,
+            label: soundEnabled ? "Sound on" : "Sound off",
+            tone: "ghost",
+            dataAttribute: "data-sound",
+          })}
+        </div>
+        <p class="hint">Move with arrow keys or WASD. Reset with R.</p>
+      </section>
+      <section class="panel board-panel">
+        ${createBoardSurfaceMarkup({
+          ariaLabel: boardAriaLabel,
+          columns: boardColumns,
+          dataAttribute: "data-board",
+        })}
+        ${createStatusBannerMarkup({
+          dataAttribute: "data-status",
+          message: statusMessage,
+          tone: won ? "won" : "default",
+        })}
+      </section>
+    </main>
+  `;
+};

--- a/src/design-system/shared/escape-html.ts
+++ b/src/design-system/shared/escape-html.ts
@@ -1,0 +1,8 @@
+export const escapeHtml = (value: string): string => {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+};

--- a/src/stories/BoardSurface.stories.ts
+++ b/src/stories/BoardSurface.stories.ts
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+
+import type { BoardSurfaceMarkupOptions } from "../design-system/components/board-surface";
+import { createBoardSurfaceMarkup } from "../design-system/components/board-surface";
+
+type BoardSurfaceStoryArgs = BoardSurfaceMarkupOptions & {
+  emphasis: "goal" | "none";
+  rows: number;
+};
+
+const createMockTile = (kind: "floor" | "goal"): string => {
+  return `<div class="tile ${kind}"><span class="piece piece-empty"></span></div>`;
+};
+
+const getEmphasisIndex = ({
+  columns,
+  rows,
+}: Pick<BoardSurfaceStoryArgs, "columns" | "rows">): number => {
+  const centerColumn = Math.floor(columns / 2);
+  const centerRow = Math.floor(rows / 2);
+
+  return centerRow * columns + centerColumn;
+};
+
+const createMockBoard = ({ columns, emphasis, rows }: BoardSurfaceStoryArgs): string => {
+  const boardMarkup = createBoardSurfaceMarkup({
+    ariaLabel: "Board surface preview",
+    columns,
+  });
+  const wrapper = document.createElement("div");
+
+  wrapper.innerHTML = boardMarkup;
+  const board = wrapper.querySelector(".board");
+  const tileCount = columns * rows;
+  const emphasisIndex = getEmphasisIndex({ columns, rows });
+  const tiles = Array.from({ length: tileCount }, (_, index) => {
+    if (emphasis === "goal" && index === emphasisIndex) {
+      return createMockTile("goal");
+    }
+
+    return createMockTile("floor");
+  });
+
+  board?.insertAdjacentHTML("beforeend", tiles.join(""));
+  return wrapper.innerHTML;
+};
+
+const createStoryFrame = (): HTMLDivElement => {
+  const frame = document.createElement("div");
+  const previewWidth = Math.max(280, Math.min(420, window.innerWidth - 48));
+
+  frame.style.width = `${previewWidth}px`;
+  frame.style.maxWidth = "calc(100vw - 40px)";
+  frame.style.padding = "12px";
+  frame.style.borderRadius = "24px";
+  frame.style.border = "1px solid rgba(200, 215, 228, 0.12)";
+  frame.style.background =
+    "linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01)), rgba(10, 19, 34, 0.76)";
+  frame.style.boxShadow = "0 18px 40px rgba(0, 0, 0, 0.22)";
+
+  return frame;
+};
+
+const meta = {
+  title: "Components/Board Surface",
+  tags: ["autodocs"],
+  render: (args) => {
+    const wrapper = createStoryFrame();
+
+    wrapper.innerHTML = createMockBoard(args);
+    return wrapper;
+  },
+  args: {
+    columns: 5,
+    emphasis: "none",
+    rows: 2,
+  },
+  argTypes: {
+    columns: {
+      control: { type: "number", min: 3, max: 9, step: 1 },
+    },
+    emphasis: {
+      control: { type: "inline-radio" },
+      options: ["none", "goal"],
+    },
+    rows: {
+      control: { type: "number", min: 2, max: 6, step: 1 },
+    },
+  },
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "This story documents the board frame as a surface specimen rather than a full puzzle board, so it uses the live preview canvas width well and keeps tile rhythm and socket placement easy to read.",
+      },
+    },
+  },
+} satisfies Meta<BoardSurfaceStoryArgs>;
+
+export default meta;
+
+type Story = StoryObj<BoardSurfaceStoryArgs>;
+
+export const Neutral: Story = {};
+
+export const GoalSocket: Story = {
+  args: {
+    emphasis: "goal",
+  },
+};

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { fn } from "storybook/test";
+
+import type { ControlButtonMarkupOptions } from "../design-system/components/button";
+import { createControlButtonMarkup } from "../design-system/components/button";
+
+type ButtonStoryArgs = ControlButtonMarkupOptions & {
+  onClick?: () => void;
+};
+
+const meta = {
+  title: "Components/Control Button",
+  tags: ["autodocs"],
+  render: ({ onClick, ...args }) => {
+    const wrapper = document.createElement("div");
+
+    wrapper.innerHTML = createControlButtonMarkup(args);
+    const button = wrapper.querySelector("button");
+
+    if (button && onClick) {
+      button.addEventListener("click", onClick);
+    }
+
+    return wrapper;
+  },
+  argTypes: {
+    tone: {
+      control: { type: "inline-radio" },
+      options: ["primary", "ghost"],
+    },
+    label: { control: "text" },
+  },
+  args: {
+    label: "Reset level",
+    onClick: fn(),
+    tone: "primary",
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Primary and ghost controls used in the game shell. These stay intentionally narrow: one tone for the main action, one tone for secondary controls.",
+      },
+    },
+  },
+} satisfies Meta<ButtonStoryArgs>;
+
+export default meta;
+
+type Story = StoryObj<ButtonStoryArgs>;
+
+export const Primary: Story = {};
+
+export const Ghost: Story = {
+  args: {
+    label: "Sound on",
+    tone: "ghost",
+  },
+};
+
+export const SoundEnabled: Story = {
+  args: {
+    ariaPressed: true,
+    label: "Sound enabled",
+    tone: "ghost",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pressed is only meaningful for toggle-like secondary actions. In the game shell this is used for stateful controls such as sound enabled.",
+      },
+    },
+  },
+};

--- a/src/stories/GameShell.stories.ts
+++ b/src/stories/GameShell.stories.ts
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+
+import type { GameShellMarkupOptions } from "../design-system/layouts/game-shell";
+import { createGameShellMarkup } from "../design-system/layouts/game-shell";
+
+const meta = {
+  title: "Layouts/Game Shell",
+  tags: ["autodocs"],
+  render: (args) => {
+    const wrapper = document.createElement("div");
+
+    wrapper.innerHTML = createGameShellMarkup(args);
+    return wrapper;
+  },
+  args: {
+    boardColumns: 9,
+    levelName: "Prototype 01",
+    moves: "0",
+    socketCount: "2",
+    soundEnabled: true,
+    statusMessage: "Level reset. Systems ready.",
+    won: false,
+  },
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "The shell is the first layout-level contract in the design system. It composes the panel surfaces, stat cards, controls, board frame, and status banner without pulling game engine logic into Storybook.",
+      },
+    },
+  },
+} satisfies Meta<GameShellMarkupOptions>;
+
+export default meta;
+
+type Story = StoryObj<GameShellMarkupOptions>;
+
+export const Default: Story = {};
+
+export const WonState: Story = {
+  args: {
+    moves: "24",
+    soundEnabled: false,
+    statusMessage: "Grid stable. All sockets are powered.",
+    won: true,
+  },
+};

--- a/src/stories/StatCard.stories.ts
+++ b/src/stories/StatCard.stories.ts
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+
+import type { StatCardMarkupOptions } from "../design-system/components/stat-card";
+import { createStatCardMarkup } from "../design-system/components/stat-card";
+
+const meta = {
+  title: "Components/Stat Card",
+  tags: ["autodocs"],
+  render: (args) => {
+    const wrapper = document.createElement("div");
+
+    wrapper.innerHTML = createStatCardMarkup(args);
+    return wrapper;
+  },
+  argTypes: {
+    label: { control: "text" },
+    value: { control: "text" },
+  },
+  args: {
+    label: "Moves",
+    value: "12",
+  },
+} satisfies Meta<StatCardMarkupOptions>;
+
+export default meta;
+
+type Story = StoryObj<StatCardMarkupOptions>;
+
+export const Moves: Story = {};
+
+export const Sockets: Story = {
+  args: {
+    label: "Sockets",
+    value: "2",
+  },
+};

--- a/src/stories/StatusBanner.stories.ts
+++ b/src/stories/StatusBanner.stories.ts
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+
+import type { StatusBannerMarkupOptions } from "../design-system/components/status-banner";
+import { createStatusBannerMarkup } from "../design-system/components/status-banner";
+
+const STATUS_BANNER_STORY_WIDTH = "640px";
+
+const meta = {
+  title: "Components/Status Banner",
+  tags: ["autodocs"],
+  render: (args) => {
+    const wrapper = document.createElement("div");
+
+    wrapper.style.width = STATUS_BANNER_STORY_WIDTH;
+    wrapper.style.maxWidth = "100%";
+    wrapper.innerHTML = createStatusBannerMarkup(args);
+    return wrapper;
+  },
+  argTypes: {
+    message: { control: "text" },
+    tone: {
+      control: { type: "inline-radio" },
+      options: ["default", "won"],
+    },
+  },
+  args: {
+    message: "Level reset. Systems ready.",
+    tone: "default",
+  },
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<StatusBannerMarkupOptions>;
+
+export default meta;
+
+type Story = StoryObj<StatusBannerMarkupOptions>;
+
+export const Default: Story = {};
+
+export const Success: Story = {
+  args: {
+    message: "Grid stable. All sockets are powered.",
+    tone: "won",
+  },
+};

--- a/src/stories/Tokens.stories.ts
+++ b/src/stories/Tokens.stories.ts
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+
+const tokenGroups = [
+  {
+    name: "Surface",
+    tokens: ["--bg-0", "--bg-1", "--bg-2", "--panel", "--panel-border"],
+  },
+  {
+    name: "Text",
+    tokens: ["--text", "--muted"],
+  },
+  {
+    name: "Accent",
+    tokens: ["--accent-warm", "--accent-hot", "--accent-cool", "--accent-win"],
+  },
+];
+
+const renderTokenSwatch = (token: string): string => {
+  return `
+    <div style="display:flex; flex-direction:column; gap:8px; min-width:160px;">
+      <div style="height:72px; border-radius:16px; border:1px solid rgba(255,255,255,0.08); background:var(${token});"></div>
+      <strong style="font-size:14px;">${token}</strong>
+    </div>
+  `;
+};
+
+const meta = {
+  title: "Foundations/Tokens",
+  tags: ["autodocs"],
+  render: () => {
+    const wrapper = document.createElement("div");
+
+    wrapper.style.display = "grid";
+    wrapper.style.gap = "24px";
+    wrapper.style.padding = "24px";
+    wrapper.innerHTML = tokenGroups
+      .map(
+        (group) => `
+          <section style="display:grid; gap:12px;">
+            <h2 style="margin:0;">${group.name}</h2>
+            <div style="display:flex; flex-wrap:wrap; gap:16px;">
+              ${group.tokens.map((token) => renderTokenSwatch(token)).join("")}
+            </div>
+          </section>
+        `,
+      )
+      .join("");
+    return wrapper;
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "The first token pass stays intentionally small: surfaces, text, and key accents. This keeps the system aligned with Material-style semantic grouping without losing the game's own palette and atmosphere.",
+      },
+    },
+  },
+} satisfies Meta;
+
+export default meta;
+export const Gallery: StoryObj = {};

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,23 +1,4 @@
-:root {
-  color-scheme: dark;
-  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
-  font-size: 16px;
-  text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  --bg-0: #08111d;
-  --bg-1: #0f1d30;
-  --bg-2: #16273d;
-  --panel: rgba(9, 15, 26, 0.76);
-  --panel-border: rgba(255, 255, 255, 0.09);
-  --text: #f5efe0;
-  --muted: #9bb2c7;
-  --accent-warm: #ffb95e;
-  --accent-hot: #ff7d48;
-  --accent-cool: #73f6ff;
-  --accent-win: #9effd9;
-  --floor: #13243b;
-  --wall: #372923;
-}
+@import "./design-system/foundations/tokens.css";
 
 * {
   box-sizing: border-box;
@@ -110,14 +91,16 @@ h1 {
   margin-top: 1.5rem;
 }
 
-.stats div {
+.stats div,
+.stat-card {
   min-width: 128px;
   padding: 16px 18px;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.055);
 }
 
-.stats strong {
+.stats strong,
+.stat-card__value {
   display: block;
   margin-top: 0.25rem;
   font-size: 30px;
@@ -132,7 +115,8 @@ h1 {
   margin-top: 1.5rem;
 }
 
-.actions button {
+.actions button,
+.control-button {
   border: 0;
   border-radius: 999px;
   padding: 14px 20px;
@@ -141,23 +125,33 @@ h1 {
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 
-.actions button:hover {
+.actions button:hover,
+.control-button:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 26px rgba(0, 0, 0, 0.24);
 }
 
-.actions button:active {
+.actions button:active,
+.control-button:active {
   transform: translateY(0);
 }
 
-.actions button:first-child {
+.actions button:first-child,
+.control-button--primary {
   background: linear-gradient(135deg, #ffe6a1 0%, var(--accent-warm) 100%);
   color: #1a1304;
 }
 
-.ghost-button {
+.ghost-button,
+.control-button--ghost {
   background: rgba(255, 255, 255, 0.06);
   color: var(--text);
+}
+
+.control-button--ghost[aria-pressed="true"] {
+  background: linear-gradient(135deg, rgba(115, 246, 255, 0.22) 0%, rgba(158, 255, 217, 0.12) 100%);
+  box-shadow: inset 0 0 0 1px rgba(115, 246, 255, 0.22), 0 0 20px rgba(115, 246, 255, 0.12);
+  color: #edfefe;
 }
 
 .hint {
@@ -168,7 +162,8 @@ h1 {
   padding: clamp(14px, 1.2vw, 20px);
 }
 
-.board {
+.board,
+.board-surface {
   width: min(100%, 672px);
   margin: 0 auto;
   display: grid;
@@ -180,7 +175,8 @@ h1 {
   transition: box-shadow 220ms ease, transform 220ms ease;
 }
 
-.board.is-winning {
+.board.is-winning,
+.board-surface.is-winning {
   box-shadow: 0 0 0 1px rgba(158, 255, 217, 0.22), 0 0 34px rgba(115, 246, 255, 0.12);
   transform: translateY(-2px);
 }
@@ -567,7 +563,8 @@ h1 {
   );
 }
 
-.status {
+.status,
+.status-banner {
   margin-top: 16px;
   padding: 16px 18px;
   border-radius: 18px;
@@ -576,7 +573,8 @@ h1 {
   transition: background 180ms ease, color 180ms ease, transform 180ms ease;
 }
 
-.status.won {
+.status.won,
+.status-banner--won {
   color: #07131e;
   background: linear-gradient(135deg, var(--accent-win) 0%, #fff3bf 100%);
   transform: translateY(-1px);
@@ -881,7 +879,8 @@ h1 {
     justify-content: center;
   }
 
-  .board {
+  .board,
+  .board-surface {
     width: min(100%, 672px, calc(100dvh - 170px));
   }
 }

--- a/src/ui/create-app-renderer.ts
+++ b/src/ui/create-app-renderer.ts
@@ -1,3 +1,4 @@
+import { createGameShellMarkup } from "../design-system/layouts/game-shell";
 import type { GameState, Level, StepResult } from "../game/types";
 import { createBoardView } from "./board-view";
 
@@ -20,7 +21,14 @@ type AppRenderer = {
 };
 
 export function createAppRenderer(options: RendererOptions): AppRenderer {
-  options.root.innerHTML = createShellMarkup(options.level);
+  options.root.innerHTML = createGameShellMarkup({
+    boardColumns: options.level.width,
+    levelName: options.level.name,
+    moves: "0",
+    socketCount: String(options.level.goals.length),
+    soundEnabled: true,
+    statusMessage: "",
+  });
 
   const board = options.root.querySelector<HTMLDivElement>("[data-board]");
   const moves = options.root.querySelector<HTMLElement>("[data-moves]");
@@ -42,48 +50,10 @@ export function createAppRenderer(options: RendererOptions): AppRenderer {
       moves.textContent = String(model.state.moves);
       status.textContent = model.statusMessage;
       status.classList.toggle("won", model.state.won);
+      status.classList.toggle("status-banner--won", model.state.won);
       soundButton.textContent = model.soundEnabled ? "Sound on" : "Sound off";
       soundButton.setAttribute("aria-pressed", String(model.soundEnabled));
       boardView.render(model.state, model.lastStep);
     },
   };
-}
-
-function createShellMarkup(level: Level): string {
-  return `
-    <main class="shell">
-      <section class="panel intro">
-        <p class="eyebrow">${level.name}</p>
-        <h1>Socket Shift</h1>
-        <p class="lede">
-          Guide the maintenance drone and push every power cell into a live socket.
-        </p>
-        <div class="stats">
-          <div>
-            <span class="label">Moves</span>
-            <strong data-moves>0</strong>
-          </div>
-          <div>
-            <span class="label">Sockets</span>
-            <strong>${level.goals.length}</strong>
-          </div>
-        </div>
-        <div class="actions">
-          <button type="button" data-reset>Reset level</button>
-          <button type="button" class="ghost-button" data-sound>Sound on</button>
-        </div>
-        <p class="hint">Move with arrow keys or WASD. Reset with R.</p>
-      </section>
-      <section class="panel board-panel">
-        <div
-          class="board"
-          data-board
-          style="grid-template-columns: repeat(${level.width}, minmax(0, 1fr));"
-          role="img"
-          aria-label="Puzzle grid with walls, sockets, power cells, and the player"
-        ></div>
-        <div class="status" data-status></div>
-      </section>
-    </main>
-  `;
 }

--- a/tests/design-system.test.ts
+++ b/tests/design-system.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { createControlButtonMarkup } from "../src/design-system/components/button";
+import { createStatusBannerMarkup } from "../src/design-system/components/status-banner";
+import { createGameShellMarkup } from "../src/design-system/layouts/game-shell";
+
+describe("createControlButtonMarkup", () => {
+  it("renders the tone class and pressed state for toggle controls", () => {
+    // Arrange
+    const options = {
+      ariaPressed: true,
+      label: "Sound on",
+      tone: "ghost",
+    } as const;
+
+    // Act
+    const markup = createControlButtonMarkup(options);
+
+    // Assert
+    expect(markup).toContain('class="control-button control-button--ghost"');
+    expect(markup).toContain('aria-pressed="true"');
+    expect(markup).toContain("Sound on");
+  });
+});
+
+describe("createStatusBannerMarkup", () => {
+  it("renders the success modifier when the banner is in a won state", () => {
+    // Arrange
+    const options = {
+      message: "Grid stable. All sockets are powered.",
+      tone: "won",
+    } as const;
+
+    // Act
+    const markup = createStatusBannerMarkup(options);
+
+    // Assert
+    expect(markup).toContain("status-banner--won");
+    expect(markup).toContain("Grid stable. All sockets are powered.");
+  });
+});
+
+describe("createGameShellMarkup", () => {
+  it("composes the shell with board, stats, controls, and status hooks", () => {
+    // Arrange
+    const options = {
+      boardColumns: 9,
+      levelName: "Prototype 01",
+      moves: "0",
+      socketCount: "2",
+      soundEnabled: true,
+      statusMessage: "Level reset. Systems ready.",
+    } as const;
+
+    // Act
+    const markup = createGameShellMarkup(options);
+
+    // Assert
+    expect(markup).toContain("data-board");
+    expect(markup).toContain("data-moves");
+    expect(markup).toContain("data-reset");
+    expect(markup).toContain("data-sound");
+    expect(markup).toContain("data-status");
+    expect(markup).toContain("grid-template-columns: repeat(9, minmax(0, 1fr));");
+  });
+});


### PR DESCRIPTION
## Summary
- add a first Storybook HTML + Vite setup for the current UI surface
- extract design-system tokens, reusable shell components, and story docs from the live prototype
- document the design-system approach and add tests for the new markup primitives

## Verification
- bun run lint
- bun run test
- bun run build
- bun run build-storybook

Closes #11